### PR TITLE
Recognize .lua files as Luau (since Roblox uses Luau)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.lua linguist-language=Luau


### PR DESCRIPTION
Basically, this will recognize that .lua files are actually LUAU files (Roblox uses Luau)

Added: 
*.lua linguist-language=Luau